### PR TITLE
feat: Add mobile navigation menu

### DIFF
--- a/src/app/components/layout/MobileNav.tsx
+++ b/src/app/components/layout/MobileNav.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Sheet, SheetContent, SheetTrigger, SheetClose } from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Menu, X } from 'lucide-react';
+
+const navLinks = [
+  { href: '#features', label: 'Features' },
+  { href: '#analytics', label: 'Analytics' },
+  { href: '#security', label: 'Security' },
+  { href: '#pricing', label: 'Pricing' },
+  { href: '#faq', label: 'FAQ' },
+  { href: '/docs', label: 'Docs' },
+];
+
+export function MobileNav() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" className="md:hidden">
+          <Menu className="h-6 w-6" />
+          <span className="sr-only">Toggle navigation menu</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="w-full max-w-xs sm:max-w-sm">
+        <div className="flex justify-between items-center py-4">
+          <Link href="/" className="flex items-center space-x-2" onClick={() => setIsOpen(false)}>
+            <div className="h-8 w-8 rounded-lg bg-primary flex items-center justify-center">
+              <span className="text-primary-foreground font-bold text-sm">HP</span>
+            </div>
+            <span className="font-bold text-xl">Hallpass</span>
+          </Link>
+          <SheetClose asChild>
+            <Button variant="ghost" size="icon">
+              <X className="h-6 w-6" />
+              <span className="sr-only">Close navigation menu</span>
+            </Button>
+          </SheetClose>
+        </div>
+        <nav className="flex flex-col space-y-4 mt-8">
+          {navLinks.map((link) => (
+            <SheetClose asChild key={link.href}>
+              <Link
+                href={link.href}
+                className="text-lg font-medium hover:text-primary transition-colors"
+                onClick={() => setIsOpen(false)}
+              >
+                {link.label}
+              </Link>
+            </SheetClose>
+          ))}
+        </nav>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/app/components/layout/SiteHeader.tsx
+++ b/src/app/components/layout/SiteHeader.tsx
@@ -5,6 +5,7 @@ import { ThemeModeToggler } from "@/components/theme-mode-toggler";
 import { ThemeColorToggler } from "@/components/theme-color-toggler";
 import { ThemeRadiusToggler } from "@/components/theme-radius-toggler";
 import { LoginButton } from "@/app/components/LoginButton";
+import { MobileNav } from "./MobileNav";
 
 export function SiteHeader() {
   return (
@@ -19,41 +20,45 @@ export function SiteHeader() {
             <span className="font-bold text-xl">Hallpass</span>
           </Link>
 
-          {/* Navigation */}
-          <nav className="hidden md:flex items-center space-x-6">
-            <Link href="#features" className="text-sm font-medium hover:text-primary transition-colors">
-              Features
-            </Link>
-            <Link href="#analytics" className="text-sm font-medium hover:text-primary transition-colors">
-              Analytics
-            </Link>
-            <Link href="#security" className="text-sm font-medium hover:text-primary transition-colors">
-              Security
-            </Link>
-            <Link href="#pricing" className="text-sm font-medium hover:text-primary transition-colors">
-              Pricing
-            </Link>
-            <Link href="#faq" className="text-sm font-medium hover:text-primary transition-colors">
-              FAQ
-            </Link>
-            <Link href="/docs" className="text-sm font-medium hover:text-primary transition-colors">
-              Docs
-            </Link>
-          </nav>
+          <div className="flex flex-1 items-center justify-end space-x-4">
+            {/* Navigation */}
+            <nav className="hidden md:flex items-center space-x-6">
+              <Link href="#features" className="text-sm font-medium hover:text-primary transition-colors">
+                Features
+              </Link>
+              <Link href="#analytics" className="text-sm font-medium hover:text-primary transition-colors">
+                Analytics
+              </Link>
+              <Link href="#security" className="text-sm font-medium hover:text-primary transition-colors">
+                Security
+              </Link>
+              <Link href="#pricing" className="text-sm font-medium hover:text-primary transition-colors">
+                Pricing
+              </Link>
+              <Link href="#faq" className="text-sm font-medium hover:text-primary transition-colors">
+                FAQ
+              </Link>
+              <Link href="/docs" className="text-sm font-medium hover:text-primary transition-colors">
+                Docs
+              </Link>
+            </nav>
 
-          {/* Actions */}
-          <div className="flex items-center space-x-4">
-            {/* Theme Controls */}
-            <div className="hidden md:flex items-center space-x-2">
-              <ThemeColorToggler />
-              <ThemeRadiusToggler />
+            {/* Actions */}
+            <div className="flex items-center space-x-4">
+              {/* Theme Controls */}
+              <div className="hidden md:flex items-center space-x-2">
+                <ThemeColorToggler />
+                <ThemeRadiusToggler />
+              </div>
+              <ThemeModeToggler />
+
+              <LoginButton variant="ghost" size="sm" />
+              <Button size="sm" asChild>
+                <Link href="/demo">Book a demo</Link>
+              </Button>
             </div>
-            <ThemeModeToggler />
 
-            <LoginButton variant="ghost" size="sm" />
-            <Button size="sm" asChild>
-              <Link href="/demo">Book a demo</Link>
-            </Button>
+            <MobileNav />
           </div>
         </div>
       </Container>


### PR DESCRIPTION
- Creates a new `MobileNav` component using a sheet for a responsive side menu.
- Integrates the `MobileNav` into the `SiteHeader`.
- Ensures the mobile navigation is displayed on small screens and the desktop navigation on larger screens.